### PR TITLE
Rename dyn_array.a libdyn_array.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ DEST_DIR= /usr/local/bin
 EXTERN_H= dyn_array.h
 EXTERN_O= dyn_array.o
 EXTERN_MAN= ${ALL_MAN_TARGETS}
-EXTERN_LIBA= dyn_array.a
+EXTERN_LIBA= libdyn_array.a
 EXTERN_PROG= dyn_test
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
@@ -283,7 +283,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and removed by clobber
 #
-LIBA_TARGETS= dyn_array.a
+LIBA_TARGETS= libdyn_array.a
 
 # shell targets to make by all and removed by clobber
 #
@@ -347,7 +347,7 @@ all: ${TARGETS} ${ALL_OTHER_TARGETS}
 dyn_array.o: dyn_array.c dyn_array.h
 	${CC} ${CFLAGS} dyn_array.c -c
 
-dyn_array.a: ${LIB_OBJS}
+libdyn_array.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
@@ -355,8 +355,8 @@ dyn_array.a: ${LIB_OBJS}
 dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
-dyn_test: dyn_test.o dyn_array.a ../dbg/dbg.a
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o dyn_array.a ../dbg/dbg.a -o dyn_test
+dyn_test: dyn_test.o ../dbg/dbg.a
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array ../dbg/dbg.a -o dyn_test
 
 
 #########################################################

--- a/README.md
+++ b/README.md
@@ -6,13 +6,37 @@ general purpose dynamic array in your program.
 
 ## Set up
 
-1. Compile `dyn_array.c` to produce `dyn_array.o`.
-2. Add `#include "dyn_array.h"` to the C source files that you wish to use the
-   facility in.
-4. Compile your source file(s) and link in `dyn_array.o`.
-
-
 For more information including an example see the next section.
+
+
+### If you do not wish to install the library:
+
+0. Compile `dyn_array.c` to produce `dyn_array.o`.
+1. Add `#include "dyn_array.h"` to the C source files that you wish to use the
+   facility in.
+2. Compile your source file(s) and link in `dyn_array.o`.
+
+
+### Installing the library:
+
+First, compile the library:
+
+```sh
+    make clobber all
+```
+
+Next, install the library (as root or via sudo):
+
+```sh
+    make install
+```
+
+Then, set up the code kind of like above, but with these changes:
+
+0. Add `#include <dyn_array.h>` to the C source files that you wish to use the
+   facility in.
+1. Compile your source file(s) and link in `dyn_array.a` (e.g. pass to the
+compiler `-ldyn_array`).
 
 
 ## The `dyn_array` API


### PR DESCRIPTION
To allow for linking in this library from say /usr/local/lib the library file has to be renamed to /usr/local/libdyn_array.a. This is a linker implementation detail. We need to have the ability to link in the dbg API in the jparse repo (https://github.com/xexyl/jparse) and this now is easier to link in and thus use the library.

The README.md set up instructions have two ways now: first what already existed, the set up of the library if you do not wish to install it and now the second, how to do it if you wish to install it.

I note that the Makefile here still refers to the dbg repo as ../dbg but it is not clear to me if this should be changed to a system install. If so that might necessitate updating the dbg README.md file (or maybe not .. not sure).