### PR TITLE
Fix Makefile for libdbg.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -364,7 +364,7 @@ dyn_test: dyn_test.o
 # rules that invoke Makefile rules in other directories #
 #########################################################
 
-../dbg/dbg.a: ../dbg/Makefile
+../dbg/libdbg.a: ../dbg/Makefile
 	${Q} ${MAKE} ${MAKE_CD_Q} -C ../dbg extern_liba C_SPECIAL=${C_SPECIAL}
 
 

--- a/Makefile
+++ b/Makefile
@@ -356,8 +356,8 @@ libdyn_array.a: ${LIB_OBJS}
 dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
-dyn_test: dyn_test.o ../dbg/dbg.a
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array ../dbg/dbg.a -o dyn_test
+dyn_test: dyn_test.o
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array -ldbg -o dyn_test
 
 
 #########################################################

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 When linked into your program, the `dyn_array` facility will give you a way to have a
 general purpose dynamic array in your program.
 
+## Dependencies
+
+In order to compile and use `dyn_array` you will need to download, compile and
+install the [dbg repo](https://github.com/lcn2/dbg).
+
+To do this, you might try:
+
+```sh
+    git clone https://github.com/lcn2/dbg
+    cd dbg && make all
+    # then as root or via sudo:
+    make install
+```
+
+and then proceed with the below steps.
+
 
 ## Set up
 


### PR DESCRIPTION
As the dbg repo is required the Makefile now links in libdbg.a rather than try and do ../dbg/dbg.a (an oversight that was missed in c8144fb58bc5675ca1dd558d3537473cfb0deb3f).

The README.md now states that one needs the dbg API installed in order to use this repo and how one might obtain it, compile and install it.