### PR TITLE
Add to Makefile -L../dbg for mkiocccentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ dyn_test.o: dyn_test.c dyn_array.h
 	${CC} ${CFLAGS} -DDBG_USE dyn_test.c -c
 
 dyn_test: dyn_test.o
-	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -ldyn_array -ldbg -o dyn_test
+	${CC} ${CFLAGS} -DDBG_USE dyn_test.o -L. -L../dbg -ldyn_array -ldbg -o dyn_test
 
 
 #########################################################


### PR DESCRIPTION
This is unfortunate but in order for the self-contained dyn_array within the mkiocccentry repo (thus not requiring the dyn_array repo or dbg repo to be installed) we have to have -L../dbg for the dbg library in the dyn_array Makefile in the mkiocccentry repo. This means that this repo has to have it too.