### PR TITLE
Improve Makefile (install, uninstall)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,13 @@ WARN_FLAGS= -pedantic -Wall -Wextra -Wno-char-subscripts
 #
 C_SPECIAL=
 
+# special linker flags
+#
+LD_SPECIAL=
+
 # linker options
 #
-LDFLAGS=
+LDFLAGS= ${LD_SPECIAL}
 
 # how to compile
 CFLAGS= ${C_STD} ${C_OPT} ${WARN_FLAGS} ${C_SPECIAL} ${LDFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,34 @@ else
 Q_V_OPTION="1"
 endif
 
+# installing variables
+#
+
 # INSTALL_V=				install w/o -v flag (quiet mode)
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# where to install
+#
+# Default PREFIX is /usr/local so binaries would be installed in /usr/local/bin,
+# libraries in /usr/local/lib etc. If one wishes to override this, say
+# installing to /usr, they can do so like:
+#
+#	make PREFIX=/usr install
+#
+PREFIX= /usr/local
+
+# uninstalling variables
+#
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -246,12 +269,12 @@ ALL_MAN_BUILT= ${MAN1_BUILT} ${MAN3_BUILT} ${MAN8_BUILT}
 
 # where to install
 #
-MAN1_DIR= /usr/local/share/man/man1
-MAN3_DIR= /usr/local/share/man/man3
-MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
-DEST_LIB= /usr/local/lib
-DEST_DIR= /usr/local/bin
+MAN1_DIR= ${PREFIX}/share/man/man1
+MAN3_DIR= ${PREFIX}/share/man/man3
+MAN8_DIR= ${PREFIX}/share/man/man8
+DEST_INCLUDE= ${PREFIX}/include
+DEST_LIB= ${PREFIX}/lib
+DEST_DIR= ${PREFIX}/bin
 
 
 #################################
@@ -614,6 +637,29 @@ install: all install_man
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_DIR}
 	${I} ${INSTALL} ${INSTALL_V} -m 0555 ${SH_TARGETS} ${PROG_TARGETS} ${DEST_DIR}
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ ending"
+
+uninstall:
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo
+	${I} ${RM} -r -f ${RM_V} ${DEST_LIB}/libdyn_array.a
+	${I} ${RM} -r -f ${RM_V} ${DEST_DIR}/dyn_test
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_rewind.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_free.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_seek.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_append_value.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_append_set.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_concat_array.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_avail.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_clear.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_tell.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_beyond.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_addr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_alloced.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dyn_array_create.3
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,37 @@ Next, install the library (as root or via sudo):
     make install
 ```
 
+If you need or want to install to a different location than the default
+`/usr/local` you can do so by changing the `PREFIX` like:
+
+```sh
+    make PREFIX=/usr install
+```
+
+
 Then, set up the code kind of like above, but with these changes:
 
 0. Add `#include <dyn_array.h>` to the C source files that you wish to use the
    facility in.
 1. Compile your source file(s) and link in `dyn_array.a` (e.g. pass to the
 compiler `-ldyn_array`).
+
+## Uninstalling
+
+If you wish to uninstall everything from this repo you can do like:
+
+```sh
+    make uninstall
+```
+
+If you changed the `PREFIX` when installing make sure to specify that. For
+instance if you installed with `PREFIX=/usr` you should do:
+
+
+```sh
+    make PREFIX=/usr uninstall
+```
+
 
 
 ## The `dyn_array` API


### PR DESCRIPTION
Add PREFIX variable to Makefile to allow for installing to a different location than the default /usr/local.

Add uninstall rule.

To be congruent with the install rule the uninstall rule has a way to silence the -v option to rm as well (instead of the install command).

Updated README.md. I note that the structure of the file could be improved upon but I do not have time for this right now.