### PR TITLE
Fix make depend

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a bug
+title: "Bug: <bug title>"
+labels: ["bug"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the problem you're reporting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: Please give a **clear** and **concise** description of what the bug is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: What you expect
+    description: |
+        Please describe what you think it should be instead and why, as best you can (the more details you provide the better).
+
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      Example:
+        - **OS**: macOS Sonoma 14.5
+        - **Device**: MacBook Pro M1
+        - **Compiler**: Apple clang version 15.0.0 (clang-1500.3.9.4)
+
+        **PLEASE** provide **AT** **LEAST** the above items. If you have the **SAME** problem with more than one device please list the above for **ALL** **RELEVANT** **devices** with **any** **relevant** **context**.
+    value: |
+        - OS:
+        - Device:
+        - Compiler:
+    render: markdown
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: bug_report.sh output
+    description: |
+      Please attach the log file of './bug_report.sh' as well as anything else you think might be useful.
+
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information that might be helpful? Please let us know!
+
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,47 @@
+name: Enhancement
+description: Suggest an enhancement
+title: "Enhancement: <enhancement title>"
+labels: ["enhancement"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you're suggesting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+
+- type: textarea
+  attributes:
+    label: Describe the enhancement
+    description: |
+        Please describe the enhancement and why, as best you can (the more details you provide the better).
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Relevant links
+    description: Please provide us with a list of relevant links, if applicable.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information? Please let us know!
+
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a feature
+title: "Feature: <feature title>"
+labels: ["Feature"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you're suggesting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+
+- type: textarea
+  attributes:
+    label: Describe the feature
+    description: |
+        Please describe the feature you would like to have and why, as best you can (the more details you provide the better).
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Relevant links
+    description: Please provide us with a list of relevant links, if applicable.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information? Please let us know!
+
+  validations:
+    required: false
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,5 @@ jobs:
       run: make picky
     - name: make check_man
       run: make check_man
+    - name: make depend
+      run: make depend

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .DS_Store
+._.DS_Store
 /Makefile.local
 /NOTES
 *.[ao]

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ dyn_array.o: dyn_array.c dyn_array.h
 	${CC} ${CFLAGS} dyn_array.c -c
 
 libdyn_array.a: ${LIB_OBJS}
-	${RM} -f $@
+	${I} ${RM} ${RM_V} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
 
@@ -565,7 +565,7 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	    echo ''; 1>&2; \
 	    exit 1; \
 	fi
-	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
+	${I} ${RM} ${RM_V} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
@@ -576,7 +576,7 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${Q} ${RM} -f tags
+	${I} ${RM} ${RM_V} -f tags
 	${Q} for dir in .; do \
 	    if [[ -s $$dir/${LOCAL_DIR_TAGS} ]]; then \
 		echo "${SED} -e 's;\t;\t'$${dir}'/;' $${dir}/${LOCAL_DIR_TAGS} >> tags"; \
@@ -599,7 +599,7 @@ legacy_clobber: legacy_clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${RM} -f dyn_array.a
+	${I} ${RM} ${RM_V} -f dyn_array.a
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -615,7 +615,7 @@ clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
+	${I} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -623,9 +623,10 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${TARGETS}
-	${RM} -f ${EXTERN_CLOBBER}
-	${RM} -f tags ${LOCAL_DIR_TAGS}
+	${I} ${RM} ${RM_V} -f ${TARGETS}
+	${I} ${RM} ${RM_V} -f ${EXTERN_CLOBBER}
+	${I} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
+	${I} ${RM} ${RM_V} -f Makefile.orig
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -635,7 +636,7 @@ install: all install_man
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
-	${I} ${RM} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
+	${I} ${RM} ${RM_V} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${LN} -s ${LIBA_TARGETS} ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
@@ -648,9 +649,9 @@ uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/libdyn_array.a
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/dyn_array.a
-	${I} ${RM} -f ${RM_V} ${DEST_DIR}/dyn_test
+	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/libdyn_array.a
+	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/dyn_array.a
+	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_DIR}/dyn_test
 	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array.3
 	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_rewind.3
 	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_free.3
@@ -693,7 +694,7 @@ depend: ${ALL_CSRC}
 		${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 		${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
-		${RM} -f Makefile.orig; \
+		${I} ${RM} ${RM_V} -f Makefile.orig; \
 	    else \
 		echo "${OUR_NAME}: Makefile dependencies updated"; \
 		echo; \

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ dyn_array.o: dyn_array.c dyn_array.h
 	${CC} ${CFLAGS} dyn_array.c -c
 
 libdyn_array.a: ${LIB_OBJS}
-	${I} ${RM} ${RM_V} -f $@
+	${Q} ${RM} ${RM_V} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
 
@@ -565,7 +565,7 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	    echo ''; 1>&2; \
 	    exit 1; \
 	fi
-	${I} ${RM} ${RM_V} -f ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
@@ -576,7 +576,7 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} ${RM_V} -f tags
+	${Q} ${RM} ${RM_V} -f tags
 	${Q} for dir in .; do \
 	    if [[ -s $$dir/${LOCAL_DIR_TAGS} ]]; then \
 		echo "${SED} -e 's;\t;\t'$${dir}'/;' $${dir}/${LOCAL_DIR_TAGS} >> tags"; \
@@ -599,7 +599,7 @@ legacy_clobber: legacy_clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} ${RM_V} -f dyn_array.a
+	${Q} ${RM} ${RM_V} -f dyn_array.a
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -615,7 +615,7 @@ clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
+	${Q} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -623,10 +623,10 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} ${RM_V} -f ${TARGETS}
-	${I} ${RM} ${RM_V} -f ${EXTERN_CLOBBER}
-	${I} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
-	${I} ${RM} ${RM_V} -f Makefile.orig
+	${Q} ${RM} ${RM_V} -f ${TARGETS}
+	${Q} ${RM} ${RM_V} -f ${EXTERN_CLOBBER}
+	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f Makefile.orig
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -636,7 +636,7 @@ install: all install_man
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
-	${I} ${RM} ${RM_V} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${LN} -s ${LIBA_TARGETS} ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
@@ -649,23 +649,23 @@ uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/libdyn_array.a
-	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/dyn_array.a
-	${I} ${RM} ${RM_V} -f ${RM_V} ${DEST_DIR}/dyn_test
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_rewind.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_free.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_seek.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_value.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_set.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_concat_array.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_avail.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_clear.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_tell.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_beyond.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_addr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_alloced.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_create.3
+	${Q} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/libdyn_array.a
+	${Q} ${RM} ${RM_V} -f ${RM_V} ${DEST_LIB}/dyn_array.a
+	${Q} ${RM} ${RM_V} -f ${RM_V} ${DEST_DIR}/dyn_test
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_rewind.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_free.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_seek.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_value.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_append_set.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_concat_array.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_avail.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_clear.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_tell.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_beyond.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_addr.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_alloced.3
+	${Q} ${RM} -f ${RM_V} ${MAN3_DIR}/dyn_array_create.3
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -694,7 +694,7 @@ depend: ${ALL_CSRC}
 		${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 		${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
-		${I} ${RM} ${RM_V} -f Makefile.orig; \
+		${Q} ${RM} ${RM_V} -f Makefile.orig; \
 	    else \
 		echo "${OUR_NAME}: Makefile dependencies updated"; \
 		echo; \

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ PREFIX= /usr/local
 # RM_V=					rm w/o -v flag (quiet mode)
 # RM_V= -v				rm with -v (debug / verbose mode)
 #
-#RM_V=
-RM_V= -v
+#RM_V= -v
+RM_V=
 
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
@@ -694,7 +694,7 @@ depend: ${ALL_CSRC}
 		${SED} -E -e 's;\s/usr/local/include/\S+;;g' -e 's;\s/usr/include/\S+;;g' | \
 		${INDEPEND} >> Makefile; \
 	    if ${CMP} -s Makefile.orig Makefile; then \
-		${Q} ${RM} ${RM_V} -f Makefile.orig; \
+		${RM} ${RM_V} -f Makefile.orig; \
 	    else \
 		echo "${OUR_NAME}: Makefile dependencies updated"; \
 		echo; \


### PR DESCRIPTION

As a series of commands the ${RM} cannot have the ${Q} in it; that is
for the start of the set of commands.

Also since the ${RM} did not in the past use -v set the ${RM_V} to empty
string by default.

What would have detected this earlier is for a make prep/release rule 
like some other repos have but at this point one does not exist. Instead
I have put this into the test workflow file.